### PR TITLE
Update views and architecture setup

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -77,11 +77,9 @@ struct ah_taint_symbolize_register_t : public action_handler_t
             uint32 flags;
             get_highlight(&selected, get_current_viewer(), &flags);
         }
-#if IDA_SDK_VERSION >= 740
         else if (ctx->widget_type == BWN_CPUREGS) {
             selected = ctx->regname;
         }
-#endif
 
         taint_symbolize_register(selected, ctx);
 
@@ -107,7 +105,6 @@ struct ah_taint_symbolize_register_t : public action_handler_t
                 }
             }                
         }
-#if IDA_SDK_VERSION >= 740
         else if (action_update_ctx->widget_type == BWN_CPUREGS) {
             auto reg_name = action_update_ctx->regname;
             if (str_to_register(reg_name) != triton::arch::register_e::ID_REG_INVALID) {
@@ -115,7 +112,6 @@ struct ah_taint_symbolize_register_t : public action_handler_t
                 action_to_take = is_debugger_on() ? AST_ENABLE : AST_DISABLE;
             }
         }
-#endif
         success = update_action_label(action_IDA_taint_symbolize_register.name, label);
         success = update_action_tooltip(action_IDA_taint_symbolize_register.name, cmdOptions.use_tainting_engine ? COMMENT_TAINT_REG : COMMENT_SYMB_REG);
 
@@ -168,13 +164,11 @@ struct ah_taint_symbolize_memory_t : public action_handler_t
                     current_ea = get_screen_ea() != -1 ? get_screen_ea() : 0;
             }                
         }
-#if IDA_SDK_VERSION >= 730
         else if (ctx->widget_type == BWN_STKVIEW) {
             if(is_mapped(ctx->cur_value))
                 current_ea = ctx->cur_value;
         }
-#endif
-        else if (ctx->widget_type == BWN_DUMP) {
+        else if (ctx->widget_type == BWN_HEXVIEW) {
             if (ctx->cur_flags & ACF_HAS_SELECTION){ // Only if there has been a valid selection
                 //We get the selection bounds from the action activation context
                 auto selection_starts = ctx->cur_sel.from.at->toea();
@@ -184,14 +178,12 @@ struct ah_taint_symbolize_memory_t : public action_handler_t
             }
         }
        
-#if IDA_SDK_VERSION >= 740
         else if (ctx->widget_type == BWN_CPUREGS) {
             auto reg_name = ctx->regname;
             uint64 reg_value;
             get_reg_val(reg_name, &reg_value);
             current_ea = reg_value;
         }
-#endif
         auto success = jumpto(current_ea, -1, UIJMP_IDAVIEW);
 
         if (!prompt_window_taint_symbolize(current_ea, abs(size), &selection_starts, &selection_ends))
@@ -253,10 +245,9 @@ struct ah_taint_symbolize_memory_t : public action_handler_t
             }
             action_to_take = is_debugger_on() ? AST_ENABLE : AST_DISABLE;
         }
-        else if (action_update_ctx_t->widget_type == BWN_DUMP) {
+        else if (action_update_ctx_t->widget_type == BWN_HEXVIEW) {
             action_to_take = is_debugger_on() ? AST_ENABLE : AST_DISABLE;    
         }
-#if IDA_SDK_VERSION >= 730
         else if (action_update_ctx_t->widget_type == BWN_STKVIEW) {
             if (is_mapped(action_update_ctx_t->cur_value)) {
                 qsnprintf(label, sizeof(label), "%s memory at " MEM_FORMAT, cmdOptions.use_tainting_engine ? "Taint" : "Symbolize", action_update_ctx_t->cur_value);
@@ -265,8 +256,7 @@ struct ah_taint_symbolize_memory_t : public action_handler_t
             else
                 action_to_take = AST_DISABLE;
         }
-#endif
-#if IDA_SDK_VERSION >= 740
+
         else if (action_update_ctx_t->widget_type == BWN_CPUREGS) {
             auto reg_name = action_update_ctx_t->regname;
             uint64 reg_value;  
@@ -280,7 +270,6 @@ struct ah_taint_symbolize_memory_t : public action_handler_t
                 action_to_take = is_debugger_on() ? AST_ENABLE : AST_DISABLE;
             }
         }
-#endif
         else {
             return AST_DISABLE;
         }

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -12,20 +12,10 @@
 
 #define __END__ -1
 
-/* Depending on the IDA version the SDK allows or not using some of the fetures we have*/
-#if IDA_SDK_VERSION < 730
-const int ponce_banner_views[] = { BWN_DISASM, BWN_DUMP, BWN_CHOOSER, __END__ };
-const int ponce_taint_symbolize_mem_views[] = { BWN_DISASM, BWN_DUMP, __END__ };
-const int ponce_taint_symbolize_reg_views[] = { BWN_DISASM, BWN_DUMP, __END__ };
-#elif IDA_SDK_VERSION == 730
-const int ponce_banner_views[] = { BWN_DISASM, BWN_DUMP, BWN_STKVIEW, BWN_CHOOSER, __END__ };
-const int ponce_taint_symbolize_mem_views[] = { BWN_DISASM, BWN_DUMP, BWN_STKVIEW, __END__ };
-const int ponce_taint_symbolize_reg_views[] = { BWN_DISASM, BWN_DUMP, BWN_STKVIEW, __END__ };
-#elif IDA_SDK_VERSION >= 740
-const int ponce_banner_views[] = { BWN_DISASM, BWN_CPUREGS, BWN_DUMP, BWN_STKVIEW, BWN_CHOOSER, __END__ };
-const int ponce_taint_symbolize_mem_views[] = { BWN_DISASM, BWN_CPUREGS, BWN_DUMP, BWN_STKVIEW, __END__ };
-const int ponce_taint_symbolize_reg_views[] = { BWN_DISASM, BWN_CPUREGS, BWN_DUMP, BWN_STKVIEW, __END__ };
-#endif
+/* IDA SDK >= 7.4 only */
+const int ponce_banner_views[] = { BWN_DISASM, BWN_CPUREGS, BWN_HEXVIEW, BWN_STKVIEW, BWN_CHOOSER, __END__ };
+const int ponce_taint_symbolize_mem_views[] = { BWN_DISASM, BWN_CPUREGS, BWN_HEXVIEW, BWN_STKVIEW, __END__ };
+const int ponce_taint_symbolize_reg_views[] = { BWN_DISASM, BWN_CPUREGS, BWN_HEXVIEW, BWN_STKVIEW, __END__ };
 
 struct IDA_actions {
     const action_desc_t* action_decs;

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -94,13 +94,6 @@ struct instruction_info {
 
 };
 extern std::map<ea_t, struct instruction_info> ponce_comments;
-/* For backwards compatibility with IDA SDKs < 7.3 */
-#if IDA_SDK_VERSION < 730
-#define inf_get_min_ea()        inf.min_ea
-#define inf_is_64bit()          inf.is_64bit()
-#define inf_is_32bit()          inf.is_32bit()
-#define WOPN_DP_TAB             WOPN_TAB
-#endif
 
 #ifdef __EA64__
 #define MEM_FORMAT "%#" PRIx64

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,15 +30,6 @@
 
 #ifdef BUILD_HEXRAYS_SUPPORT
 #include "ponce_hexrays.hpp"
-
-#if IDA_SDK_VERSION < 760
-// Hex-Rays API pointer
-hexdsp_t* hexdsp = NULL;
-#endif
-#endif
-
-#if IDA_SDK_VERSION < 700
-#error "Ponce does not support IDA < 7.0"
 #endif
 
 #define stringify_literal( x ) # x
@@ -127,13 +118,7 @@ bool idaapi run(size_t)
 }
 
 //--------------------------------------------------------------------------
-#if IDA_SDK_VERSION >= 760
 plugmod_t* idaapi init(void)
-#elif IDA_SDK_VERSION == 750
-size_t idaapi init(void)
-#else
-int idaapi init(void)
-#endif
 {
     char runtimeVersion[8];
     //We do some checks with the versions...

--- a/src/ponce_hexrays.hpp
+++ b/src/ponce_hexrays.hpp
@@ -12,11 +12,7 @@
 
 #ifdef BUILD_HEXRAYS_SUPPORT
 #include <hexrays.hpp>
-#if IDA_SDK_VERSION == 700
-int idaapi ponce_hexrays_callback(void*, hexrays_event_t event, va_list va);
-#else
 ssize_t idaapi ponce_hexrays_callback(void*, hexrays_event_t event, va_list va);
-#endif
 #endif
 
 extern bool hexrays_present;

--- a/src/triton_logic.cpp
+++ b/src/triton_logic.cpp
@@ -154,20 +154,20 @@ int tritonize(ea_t pc, thid_t threadID)
 }
 
 bool ponce_set_triton_architecture() {
-    if (ph.id == PLFM_386) {
-        if (ph.use64())
+    if (PH.id == PLFM_386) {
+        if (PH.use64())
             tritonCtx.setArchitecture(triton::arch::ARCH_X86_64);
-        else if (ph.use32())
+        else if (PH.use32())
             tritonCtx.setArchitecture(triton::arch::ARCH_X86);
         else {
             msg("[e] Wrong architecture\n");
             return false;
         }
     }
-    else if (ph.id == PLFM_ARM) {
-        if (ph.use64())
+    else if (PH.id == PLFM_ARM) {
+        if (PH.use64())
             tritonCtx.setArchitecture(triton::arch::ARCH_AARCH64);
-        else if (ph.use32())
+        else if (PH.use32())
             tritonCtx.setArchitecture(triton::arch::ARCH_ARM32);
         else {
             msg("[e] Wrong architecture\n");


### PR DESCRIPTION
## Summary
- modernize supported view flags
- rename processor descriptor usage to PH for architecture detection

## Testing
- `cmake -B build -S .` *(fails: You should set IDASDK_ROOT_DIR to the IDA SDK path)*

------
https://chatgpt.com/codex/tasks/task_b_683d56b84bb8833295a805adbbff4960